### PR TITLE
Add Smithery CLI Installation Instructions & Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A Model Context Protocol (MCP) server implementation that integrates with FireCr
 
 ## Features
 
+[![smithery badge](https://smithery.ai/badge/mcp-server-firecrawl)](https://smithery.ai/server/mcp-server-firecrawl)
+
 - **JavaScript Rendering**: Extract content from JavaScript-heavy websites
 - **Mobile/Desktop Views**: Support for different viewport configurations
 - **Smart Rate Limiting**: Built-in rate limit handling
@@ -44,6 +46,14 @@ Checks the status of a batch scraping job.
   - `id` (string): Batch job ID to check
 
 ## Installation
+
+### Installing via Smithery
+
+To install FireCrawl for Claude Desktop automatically via [Smithery](https://smithery.ai/server/mcp-server-firecrawl):
+
+```bash
+npx -y @smithery/cli install mcp-server-firecrawl --client claude
+```
 
 ```bash
 npm install mcp-server-firecrawl

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # FireCrawl MCP Server
+[![smithery badge](https://smithery.ai/badge/mcp-server-firecrawl)](https://smithery.ai/server/mcp-server-firecrawl)
 
 A Model Context Protocol (MCP) server implementation that integrates with FireCrawl for advanced web scraping capabilities.
 
 ## Features
-
-[![smithery badge](https://smithery.ai/badge/mcp-server-firecrawl)](https://smithery.ai/server/mcp-server-firecrawl)
 
 - **JavaScript Rendering**: Extract content from JavaScript-heavy websites
 - **Mobile/Desktop Views**: Support for different viewport configurations
@@ -55,6 +54,7 @@ To install FireCrawl for Claude Desktop automatically via [Smithery](https://smi
 npx -y @smithery/cli install mcp-server-firecrawl --client claude
 ```
 
+### Manual Installation
 ```bash
 npm install mcp-server-firecrawl
 ```


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install FireCrawl for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/mcp-server-firecrawl

Let me know if any tweaks have to be made!